### PR TITLE
add pay to user to offer types, handle new type in order history screen

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/CreateExternalOrderCall.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/CreateExternalOrderCall.java
@@ -51,7 +51,7 @@ class CreateExternalOrderCall extends Thread {
 			openOrder = remote.createExternalOrderSync(orderJwt);
 			sendOrderCreationReceivedEvent();
 
-			if (openOrder.getOfferType() == OfferType.SPEND) {
+			if (openOrder.getOfferType() == OfferType.SPEND || openOrder.getOfferType() == OfferType.PAY_TO_USER) {
 				Balance balance = blockchainSource.getBalance();
 				if (balance.getAmount().intValue() < openOrder.getAmount()) {
 					remote.cancelOrderSync(openOrder.getId());
@@ -132,6 +132,9 @@ class CreateExternalOrderCall extends Thread {
 				case EARN:
 					//TODO add event
 					// We don't have event correctly
+				case PAY_TO_USER:
+					//TODO add event
+					// We don't have event correctly
 					break;
 			}
 
@@ -146,6 +149,7 @@ class CreateExternalOrderCall extends Thread {
 						.create(openOrder.getOfferId(), openOrder.getId(), true));
 					break;
 				case EARN:
+				case PAY_TO_USER:
 					break;
 			}
 		}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/network/model/Offer.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/network/model/Offer.java
@@ -41,7 +41,8 @@ public class Offer {
 	public enum OfferType {
 
 		EARN("earn"),
-		SPEND("spend");
+		SPEND("spend"),
+		PAY_TO_USER("pay_to_user");
 
 		private String value;
 


### PR DESCRIPTION
* Main purpose:
Bug fix - "pay to user" order appeared in order history screen as an "earn" order for both sides of the order (sender and recipient user)
* Technical description: 
 - added new `OfferType` of pay to user
 - now balance check will be done before pay to user order
 - order history pay to user handling added + some bug fixes (some of the ui wasn't set in the case of failure, so it was 'inherited' the previous value of recycled view holder)
* Dilemmas you faced with? 
 n/a
* Tests
 n/a
* Documentation (Source/readme.md)
n/a