### PR TITLE
Rs512 >es256

### DIFF
--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -83,8 +83,8 @@ def loadCredential() {
     def crashlytics_demo_api_key = "4b7647b5860d29039e16910e281fcf8d9cad21bb"
     def default_app_id = '"test"'
     def default_api_key = '"AyINT44OAKagkSav2vzMz"'
-    def default_rs512_jwt_private_key = '"MIICXgIBAAKBgQDW3g5Acwjxdyh+OLi8NH9jO4KEOruXozCbhsXL+CYGIG1sYykk/P1nPWiy7rlVHWy5x9B2pYtKb+vm/DaZ5gpTqzlb9D964yKRvWlCLCOjyLN/zh1/xHoieQ530kveTYY+tZHz1QzXnIOlxF6HjscU8PtDWw85CKngzgVA9oS4KwIDAQABAoGBAJwq/u7G7VwbQDolXdekzGXCbgVPbuMyv/R6Sy8JqBFR5lYd6Fyy6DbuQjezHM8JOOn6mcByZ7/tgub6r3DB6wQ6ALmvmVztCt9BH7eP1X/VFQavqYhmrXBfTBVhGmK/qDvBzZWIQENuaSspBzxp7Ujl0CuevyfbSgb/s8FlEyxhAkEA7J2ecPHcoeNMZc388CiLZ94CowSi6il3lkODK9/TXtx/LuW3iUhvSHp90tcMfI7sWGuXUGYqwvu+ij20d6en2wJBAOh4UxIXNcYcAfaLaCYji4GN4D9fp3/vK3hvk3f+X3uFgDRS8sp0Su0xYsrY7CMwJBCVH++qdIosKZ5RgSErCfECQQCZyvUhykKywo90mEewPVom/8lM9gWCF8PP2j/W85tqS/0qmUsLIxaZ0GwZ74cBKtB5xCzMqCthIsm9BtBW+ZUDAkBjbiuhvjmqzYntaL0YKvXdaNB0arZa2vJN5fM+TJeMXpJyTtQ30bvGbewidNuzRUD3ssDhIpgMDU2TwKqphB4RAkEAp+a7ra80Jlb+r1ab9rkO0LHfHng2qmRTDq1i/PQ7OVob/qwUkYPn75DOg2qONFBmEUgcQS/MQ9SE13mdszMvzw=="'
-    def default_rs512_jwt_private_key_id = '"rs512_0"'
+    def default_rs512_jwt_private_key = '"MIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQgSu7aMsjm065XMI+d8HuIt6pg8vP6kXzEIUWWNUEJnQmhRANCAATmmkRSAHNFClxx/1quX+3Gjy3qEOkY+crVLFVOlp2OuUKLhiYozjFUTPJhKw5Ae9YDojvSBPQPJXFKTrjOxjQw"'
+    def default_rs512_jwt_private_key_id = '"es256_0"'
     ant.propertyfile(file: "credential.properties") {
         entry(key: "APP_ID", default: System.getenv('APP_ID') ?: default_app_id)
         entry(key: "API_KEY", default: System.getenv('API_KEY') ?: default_api_key)

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -40,8 +40,8 @@ android {
         loadCredential()
         buildConfigField "String", "SAMPLE_APP_ID", credentialProperties.getProperty("APP_ID")
         buildConfigField "String", "SAMPLE_API_KEY", credentialProperties.getProperty("API_KEY")
-        buildConfigField "String", "RS512_PRIVATE_KEY", credentialProperties.getProperty("RS512_PRIVATE_KEY")
-        buildConfigField "String", "RS512_PRIVATE_KEY_ID", credentialProperties.getProperty("RS512_PRIVATE_KEY_ID")
+        buildConfigField "String", "ES256_PRIVATE_KEY", credentialProperties.getProperty("ES256_PRIVATE_KEY")
+        buildConfigField "String", "ES256_PRIVATE_KEY_ID", credentialProperties.getProperty("ES256_PRIVATE_KEY_ID")
         buildConfigField "boolean", "IS_JWT_REGISTRATION", credentialProperties.getProperty("IS_JWT_REGISTRATION")
 
         manifestPlaceholders = [crashlytics_api_key: credentialProperties.getProperty("CRASHLYTICS_API_KEY")]
@@ -88,8 +88,8 @@ def loadCredential() {
     ant.propertyfile(file: "credential.properties") {
         entry(key: "APP_ID", default: System.getenv('APP_ID') ?: default_app_id)
         entry(key: "API_KEY", default: System.getenv('API_KEY') ?: default_api_key)
-        entry(key: "RS512_PRIVATE_KEY", default: System.getenv('RS512_PRIVATE_KEY') ?: default_rs512_jwt_private_key)
-        entry(key: "RS512_PRIVATE_KEY_ID", default: System.getenv('RS512_PRIVATE_KEY_ID') ?: default_rs512_jwt_private_key_id)
+        entry(key: "ES256_PRIVATE_KEY", default: System.getenv('RS512_PRIVATE_KEY') ?: default_rs512_jwt_private_key)
+        entry(key: "ES256_PRIVATE_KEY_ID", default: System.getenv('RS512_PRIVATE_KEY_ID') ?: default_rs512_jwt_private_key_id)
         entry(key: "IS_JWT_REGISTRATION", default: System.getenv('IS_JWT_REGISTRATION') ?:  "false")
         entry(key: "CRASHLYTICS_API_KEY", default: System.getenv('CRASHLYTICS_API_KEY')  ?: crashlytics_demo_api_key)
     }

--- a/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
+++ b/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
@@ -79,11 +79,11 @@ public class JwtUtil {
 
 	@NonNull
 	private static String getPrivateKeyForJWT() {
-		return BuildConfig.RS512_PRIVATE_KEY;
+		return BuildConfig.ES256_PRIVATE_KEY;
 	}
 
 	private static JwtBuilder getBasicJWT(String appID) {
-		return Jwts.builder().setHeaderParam(JWT_HEADER_KID, BuildConfig.RS512_PRIVATE_KEY_ID)
+		return Jwts.builder().setHeaderParam(JWT_HEADER_KID, BuildConfig.ES256_PRIVATE_KEY_ID)
 			.setHeaderParam(JWT_HEADER_TYP, JWT)
 			.setIssuedAt(new Date())
 			.setIssuer(appID)

--- a/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
+++ b/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
@@ -9,17 +9,14 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Date;
 import java.util.Random;
 
 public class JwtUtil {
-
-	private static final String ALGORITHM_RSA = "RSA";
-	private static final String SECURITY_PROVIDER_BC = "BC";
 
 	private static final long DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
@@ -39,12 +36,12 @@ public class JwtUtil {
 
 	private static final String JWT = "jwt";
 
-
 	public static String generateSignInExampleJWT(@NonNull String appID, @NonNull String userId) {
+
 		String jwt = getBasicJWT(appID)
 			.setSubject(JWT_SUBJECT_REGISTER)
 			.claim(JWT_KEY_USER_ID, userId)
-			.signWith(SignatureAlgorithm.RS512, getRS512PrivateKey()).compact();
+			.signWith(SignatureAlgorithm.ES256, getES256PrivateKey()).compact();
 		return jwt;
 	}
 
@@ -53,7 +50,7 @@ public class JwtUtil {
 			.setSubject(JWT_SUBJECT_SPEND)
 			.claim(JWT_CLAIM_OBJECT_OFFER_PART, createOfferPartExampleObject())
 			.claim(JWT_CLAIM_OBJECT_SENDER_PART, new JWTSenderPart(userID, "Bought a sticker", "Lion sticker"))
-			.signWith(SignatureAlgorithm.RS512, getRS512PrivateKey()).compact();
+			.signWith(SignatureAlgorithm.ES256, getES256PrivateKey()).compact();
 		return jwt;
 	}
 
@@ -63,7 +60,7 @@ public class JwtUtil {
 			.claim(JWT_CLAIM_OBJECT_OFFER_PART, createOfferPartExampleObject())
 			.claim(JWT_CLAIM_OBJECT_RECIPIENT_PART,
 				new JWTRecipientPart(userID, "Received Kin", "upload profile picture"))
-			.signWith(SignatureAlgorithm.RS512, getRS512PrivateKey()).compact();
+			.signWith(SignatureAlgorithm.ES256, getES256PrivateKey()).compact();
 		return jwt;
 	}
 
@@ -75,7 +72,7 @@ public class JwtUtil {
 			.claim(JWT_CLAIM_OBJECT_SENDER_PART, new JWTSenderPart(userID, "Uploaded Profile Picture", "Lion sticker"))
 			.claim(JWT_CLAIM_OBJECT_RECIPIENT_PART,
 				new JWTRecipientPart(recipientUserID, "Received Kin", "Upload profile picture"))
-			.signWith(SignatureAlgorithm.RS512, getRS512PrivateKey()).compact();
+			.signWith(SignatureAlgorithm.ES256, getES256PrivateKey()).compact();
 		return jwt;
 	}
 
@@ -93,25 +90,16 @@ public class JwtUtil {
 	}
 
 	@Nullable
-	private static PrivateKey getRS512PrivateKey() {
-		PrivateKey privateKey = null;
-		KeyFactory keyFactory;
-
-		byte[] bytes = Base64.decode(getPrivateKeyForJWT(), Base64.NO_WRAP);
+	private static PrivateKey getES256PrivateKey() {
 		try {
-			keyFactory = KeyFactory.getInstance(ALGORITHM_RSA, SECURITY_PROVIDER_BC);
-			privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(bytes));
-
-		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
-
-		} catch (InvalidKeySpecException e) {
-			e.printStackTrace();
-
-		} catch (NoSuchProviderException e) {
+			KeyFactory kf = KeyFactory.getInstance("EC");
+			byte[] bytes = Base64.decode(getPrivateKeyForJWT(), Base64.NO_WRAP);
+			EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(bytes);
+			return kf.generatePrivate(keySpec);
+		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
 			e.printStackTrace();
 		}
-		return privateKey;
+		return null;
 	}
 
 	private static JWTOfferPart createOfferPartExampleObject() {

--- a/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
+++ b/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
@@ -20,20 +20,21 @@ public class JwtUtil {
 
 	private static final long DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
+	private static final String ALGORITHM_EC = "EC";
 	private static final String JWT_CLAIM_OBJECT_OFFER_PART = "offer";
 	private static final String JWT_CLAIM_OBJECT_SENDER_PART = "sender"; // Should be part of native SPEND jwt
-	private static final String JWT_CLAIM_OBJECT_RECIPIENT_PART = "recipient"; // Should be part of native EARN jwt
 
+	private static final String JWT_CLAIM_OBJECT_RECIPIENT_PART = "recipient"; // Should be part of native EARN jwt
 	private static final String JWT_SUBJECT_REGISTER = "register";
 	private static final String JWT_SUBJECT_SPEND = "spend";
 	private static final String JWT_SUBJECT_EARN = "earn";
+
 	private static final String JWT_SUBJECT_PAY_TO_USER = "pay_to_user";
 
 	private static final String JWT_KEY_USER_ID = "user_id";
-
 	private static final String JWT_HEADER_KID = "kid";
-	private static final String JWT_HEADER_TYP = "typ";
 
+	private static final String JWT_HEADER_TYP = "typ";
 	private static final String JWT = "jwt";
 
 	public static String generateSignInExampleJWT(@NonNull String appID, @NonNull String userId) {
@@ -92,7 +93,7 @@ public class JwtUtil {
 	@Nullable
 	private static PrivateKey getES256PrivateKey() {
 		try {
-			KeyFactory kf = KeyFactory.getInstance("EC");
+			KeyFactory kf = KeyFactory.getInstance(ALGORITHM_EC);
 			byte[] bytes = Base64.decode(getPrivateKeyForJWT(), Base64.NO_WRAP);
 			EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(bytes);
 			return kf.generatePrivate(keySpec);


### PR DESCRIPTION
* Main purpose:
  Change the used JWT signing algorithm to es256 instead of rs512.
  Update 'test' app key to es256
* Technical description:
The code change is minimal (replacing algorithm), but the JWT private key is required to be in PKCS#8 format instead of the generated by JWT Service PKCS#1. a simple openssl command can be used to transform it.
* Dilemmas you faced with?
* Tests
Tested against playground with test app
* Documentation (Source/readme.md)
updated in kin sdk docs