### PR TITLE
add logging to BI for error with loading order history

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/bi/events/GeneralEcosystemSdkError.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/bi/events/GeneralEcosystemSdkError.java
@@ -1,0 +1,173 @@
+
+package kin.devplatform.bi.events;
+
+// Augmented by script
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import kin.devplatform.bi.Event;
+import kin.devplatform.bi.EventsStore;
+
+
+/**
+ * General exception event
+ */
+public class GeneralEcosystemSdkError implements Event {
+
+	public static final String EVENT_NAME = "general_ecosystem_sdk_error";
+	public static final String EVENT_TYPE = "log";
+
+	// Augmented by script
+	public static GeneralEcosystemSdkError create(String errorReason) {
+		return new GeneralEcosystemSdkError(
+			(Common) EventsStore.common(),
+			(User) EventsStore.user(),
+			(Client) EventsStore.client(),
+			errorReason);
+	}
+
+	/**
+	 * (Required)
+	 */
+	@SerializedName("event_name")
+	@Expose
+	private String eventName = EVENT_NAME;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("event_type")
+	@Expose
+	private String eventType = EVENT_TYPE;
+	/**
+	 * common properties for all events (Required)
+	 */
+	@SerializedName("common")
+	@Expose
+	private Common common;
+	/**
+	 * common user properties (Required)
+	 */
+	@SerializedName("user")
+	@Expose
+	private User user;
+	/**
+	 * common properties for all client events (Required)
+	 */
+	@SerializedName("client")
+	@Expose
+	private Client client;
+	/**
+	 * (Required)
+	 */
+	@SerializedName("error_reason")
+	@Expose
+	private String errorReason;
+
+	/**
+	 * No args constructor for use in serialization
+	 */
+	public GeneralEcosystemSdkError() {
+	}
+
+	/**
+	 *
+	 * @param common
+	 * @param errorReason
+
+	 * @param client
+
+	 * @param user
+	 */
+	public GeneralEcosystemSdkError(Common common, User user, Client client, String errorReason) {
+		super();
+		this.common = common;
+		this.user = user;
+		this.client = client;
+		this.errorReason = errorReason;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public String getEventName() {
+		return eventName;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setEventName(String eventName) {
+		this.eventName = eventName;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public String getEventType() {
+		return eventType;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setEventType(String eventType) {
+		this.eventType = eventType;
+	}
+
+	/**
+	 * common properties for all events (Required)
+	 */
+	public Common getCommon() {
+		return common;
+	}
+
+	/**
+	 * common properties for all events (Required)
+	 */
+	public void setCommon(Common common) {
+		this.common = common;
+	}
+
+	/**
+	 * common user properties (Required)
+	 */
+	public User getUser() {
+		return user;
+	}
+
+	/**
+	 * common user properties (Required)
+	 */
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	/**
+	 * common properties for all client events (Required)
+	 */
+	public Client getClient() {
+		return client;
+	}
+
+	/**
+	 * common properties for all client events (Required)
+	 */
+	public void setClient(Client client) {
+		this.client = client;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public String getErrorReason() {
+		return errorReason;
+	}
+
+	/**
+	 * (Required)
+	 */
+	public void setErrorReason(String errorReason) {
+		this.errorReason = errorReason;
+	}
+
+}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/history/presenter/OrderHistoryPresenter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/history/presenter/OrderHistoryPresenter.java
@@ -2,6 +2,7 @@ package kin.devplatform.history.presenter;
 
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +10,7 @@ import kin.devplatform.KinCallback;
 import kin.devplatform.base.BasePresenter;
 import kin.devplatform.base.Observer;
 import kin.devplatform.bi.EventLogger;
+import kin.devplatform.bi.events.GeneralEcosystemSdkError;
 import kin.devplatform.bi.events.OrderHistoryItemTapped;
 import kin.devplatform.bi.events.OrderHistoryPageViewed;
 import kin.devplatform.bi.events.SpendRedeemPageViewed.RedeemTrigger;
@@ -67,7 +69,9 @@ public class OrderHistoryPresenter extends BasePresenter<IOrderHistoryView> impl
 
 			@Override
 			public void onFailure(KinEcosystemException exception) {
-
+				eventLogger.send(GeneralEcosystemSdkError
+					.create("OrderHistoryPresenter.getOrderHistoryList onFailure. exception = " + Log
+						.getStackTraceString(exception)));
 			}
 		});
 	}


### PR DESCRIPTION
* Main purpose:
 Add logging to BI for error with loading order history, in order to track cases where blank history would appear
* Technical description:
"Borrow" `GeneralEcosystemSdkError` event from ecosystem
* Dilemmas you faced with?
* Tests
* Documentation (Source/readme.md)