### PR TITLE
Dp 131 crash in order history due to empty desc

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
@@ -148,17 +148,19 @@ public class OrderHistoryRecyclerAdapter extends BaseRecyclerAdapter<Order, View
 		}
 
 		private void setSubtitle(Order item) {
-			if (item.getDescription() != null) {
-				StringBuilder subTitle = new StringBuilder(item.getDescription());
-				String dateString = item.getCompletionDate();
-				if (dateString != null && !TextUtils.isEmpty(dateString)) {
-					dateString = getDateFormatted(dateString);
-					if (!TextUtils.isEmpty(dateString)) {
-						subTitle.append(DASH_DELIMITER).append(dateString);
-					}
+			String desc = item.getDescription();
+			String dateString = item.getCompletionDate();
+			dateString = getDateFormatted(dateString);
+			String subTitle = null;
+
+			if (dateString != null && !TextUtils.isEmpty(dateString)) {
+				if (TextUtils.isEmpty(desc)) {
+					subTitle = dateString;
+				} else {
+					subTitle = desc + DASH_DELIMITER + dateString;
 				}
-				setText(R.id.sub_title, subTitle);
 			}
+			setText(R.id.sub_title, subTitle);
 		}
 
 		private void setOrderTitle(Order item) {

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
@@ -148,15 +148,17 @@ public class OrderHistoryRecyclerAdapter extends BaseRecyclerAdapter<Order, View
 		}
 
 		private void setSubtitle(Order item) {
-			StringBuilder subTitle = new StringBuilder(item.getDescription());
-			String dateString = item.getCompletionDate();
-			if (dateString != null && !TextUtils.isEmpty(dateString)) {
-				dateString = getDateFormatted(dateString);
-				if (!TextUtils.isEmpty(dateString)) {
-					subTitle.append(DASH_DELIMITER).append(dateString);
+			if (item.getDescription() != null) {
+				StringBuilder subTitle = new StringBuilder(item.getDescription());
+				String dateString = item.getCompletionDate();
+				if (dateString != null && !TextUtils.isEmpty(dateString)) {
+					dateString = getDateFormatted(dateString);
+					if (!TextUtils.isEmpty(dateString)) {
+						subTitle.append(DASH_DELIMITER).append(dateString);
+					}
 				}
+				setText(R.id.sub_title, subTitle);
 			}
-			setText(R.id.sub_title, subTitle);
 		}
 
 		private void setOrderTitle(Order item) {

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/history/view/OrderHistoryRecyclerAdapter.java
@@ -152,12 +152,16 @@ public class OrderHistoryRecyclerAdapter extends BaseRecyclerAdapter<Order, View
 			String dateString = item.getCompletionDate();
 			dateString = getDateFormatted(dateString);
 			String subTitle = null;
+			StringBuilder sb = new StringBuilder();
 
 			if (dateString != null && !TextUtils.isEmpty(dateString)) {
 				if (TextUtils.isEmpty(desc)) {
 					subTitle = dateString;
 				} else {
-					subTitle = desc + DASH_DELIMITER + dateString;
+					sb.append(desc)
+						.append(DASH_DELIMITER)
+						.append(dateString);
+					subTitle = sb.toString();
 				}
 			}
 			setText(R.id.sub_title, subTitle);

--- a/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
+++ b/sample-app/src/main/java/kin/devplatform/sample/JwtUtil.java
@@ -60,7 +60,7 @@ public class JwtUtil {
 			.setSubject(JWT_SUBJECT_EARN)
 			.claim(JWT_CLAIM_OBJECT_OFFER_PART, createOfferPartExampleObject())
 			.claim(JWT_CLAIM_OBJECT_RECIPIENT_PART,
-				new JWTRecipientPart(userID, "Received Kin", "upload profile picture"))
+				new JWTRecipientPart(userID, "Received Kin", null))
 			.signWith(SignatureAlgorithm.ES256, getES256PrivateKey()).compact();
 		return jwt;
 	}


### PR DESCRIPTION
* Main purpose:
 Crash when description in order is null
* Technical description:
Take this into consideration when generating order subtitle in order history screen, in case of empty description display only the date.
Add this case to sample app in native earn, so we will test it always in sample app.
* Dilemmas you faced with?
* Tests
Tested manually
* Documentation (Source/readme.md)