### PR TITLE
DP-148 - fix crash in OrderHistory after activity restart

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/main/presenter/IEcosystemPresenter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/main/presenter/IEcosystemPresenter.java
@@ -1,5 +1,6 @@
 package kin.devplatform.main.presenter;
 
+import android.os.Bundle;
 import kin.devplatform.base.IBasePresenter;
 import kin.devplatform.main.ScreenId;
 import kin.devplatform.main.view.IEcosystemView;
@@ -17,4 +18,6 @@ public interface IEcosystemPresenter extends IBasePresenter<IEcosystemView> {
 	void onMenuInitialized();
 
 	void onStart();
+
+	void onSaveInstanceState(Bundle outState);
 }

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/main/view/EcosystemActivity.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/main/view/EcosystemActivity.java
@@ -8,6 +8,8 @@ import static kin.devplatform.main.Title.ORDER_HISTORY_TITLE;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager.BackStackEntry;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.MenuItemCompat;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -44,6 +46,7 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 
 	public static final String ECOSYSTEM_MARKETPLACE_FRAGMENT_TAG = "ecosystem_marketplace_fragment_tag";
 	public static final String ECOSYSTEM_ORDER_HISTORY_FRAGMENT_TAG = "ecosystem_order_history_fragment_tag";
+	public static final String MARKETPLACE_TO_ORDER_HISTORY = "marketplace_to_order_history";
 
 	private IBalancePresenter balancePresenter;
 	private IEcosystemPresenter ecosystemPresenter;
@@ -90,13 +93,19 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 		});
 		ecosystemPresenter = new EcosystemPresenter(this,
 			new SettingsDataSourceImpl(new SettingsDataSourceLocal(getApplicationContext())),
-			BlockchainSourceImpl.getInstance(), this);
+			BlockchainSourceImpl.getInstance(), this, savedInstanceState);
 	}
 
 	@Override
 	protected void onStart() {
 		super.onStart();
 		ecosystemPresenter.onStart();
+	}
+
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		ecosystemPresenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override
@@ -152,8 +161,7 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 
 	@Override
 	public void navigateToMarketplace() {
-		MarketplaceFragment marketplaceFragment = (MarketplaceFragment) getSupportFragmentManager()
-			.findFragmentByTag(ECOSYSTEM_MARKETPLACE_FRAGMENT_TAG);
+		MarketplaceFragment marketplaceFragment = getSavedMarketplaceFragment();
 		if (marketplaceFragment == null) {
 			marketplaceFragment = MarketplaceFragment.newInstance();
 		}
@@ -165,6 +173,11 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 			.commit();
 
 		setVisibleScreen(MARKETPLACE);
+	}
+
+	private MarketplaceFragment getSavedMarketplaceFragment() {
+		return (MarketplaceFragment) getSupportFragmentManager()
+			.findFragmentByTag(ECOSYSTEM_MARKETPLACE_FRAGMENT_TAG);
 	}
 
 	private IMarketplacePresenter getMarketplacePresenter(MarketplaceFragment marketplaceFragment) {
@@ -188,9 +201,11 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 	public void navigateToOrderHistory(boolean isFirstSpendOrder) {
 		OrderHistoryFragment orderHistoryFragment = (OrderHistoryFragment) getSupportFragmentManager()
 			.findFragmentByTag(ECOSYSTEM_ORDER_HISTORY_FRAGMENT_TAG);
-
+		boolean shouldAddToBackStack = true;
 		if (orderHistoryFragment == null) {
 			orderHistoryFragment = OrderHistoryFragment.newInstance();
+		} else {
+			shouldAddToBackStack = false;
 		}
 
 		new OrderHistoryPresenter(orderHistoryFragment,
@@ -198,14 +213,19 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 			EventLoggerImpl.getInstance(),
 			isFirstSpendOrder);
 
-		getSupportFragmentManager().beginTransaction()
+		FragmentTransaction transaction = getSupportFragmentManager().beginTransaction()
 			.setCustomAnimations(
 				R.anim.kinecosystem_slide_in_right,
 				R.anim.kinecosystem_slide_out_left,
 				R.anim.kinrecovery_slide_in_left,
 				R.anim.kinecosystem_slide_out_right)
-			.replace(R.id.fragment_frame, orderHistoryFragment, ECOSYSTEM_ORDER_HISTORY_FRAGMENT_TAG)
-			.addToBackStack(null).commit();
+			.replace(R.id.fragment_frame, orderHistoryFragment, ECOSYSTEM_ORDER_HISTORY_FRAGMENT_TAG);
+
+		if (shouldAddToBackStack) {
+			transaction.addToBackStack(MARKETPLACE_TO_ORDER_HISTORY);
+		}
+
+		transaction.commit();
 
 		setVisibleScreen(ORDER_HISTORY);
 	}
@@ -246,6 +266,19 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 			super.onBackPressed();
 			overridePendingTransition(0, R.anim.kinecosystem_slide_out_right);
 		} else {
+			BackStackEntry entry = getSupportFragmentManager().getBackStackEntryAt(count - 1);
+			if (entry != null && entry.getName().equals(MARKETPLACE_TO_ORDER_HISTORY)) {
+				// After pressing back from OrderHistory, should put the attrs again.
+				// This is the only fragment that should set presenter again on back.
+				MarketplaceFragment marketplaceFragment = getSavedMarketplaceFragment();
+				if (marketplaceFragment != null) {
+					if (marketplacePresenter == null) {
+						getMarketplacePresenter(marketplaceFragment);
+					} else {
+						marketplaceFragment.attachPresenter(marketplacePresenter);
+					}
+				}
+			}
 			getSupportFragmentManager().popBackStackImmediate();
 			setVisibleScreen(MARKETPLACE);
 		}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/marketplace/view/IMarketplaceView.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/marketplace/view/IMarketplaceView.java
@@ -2,12 +2,12 @@ package kin.devplatform.marketplace.view;
 
 import java.util.List;
 import kin.devplatform.base.IBaseView;
+import kin.devplatform.marketplace.presenter.IMarketplacePresenter;
 import kin.devplatform.marketplace.presenter.ISpendDialogPresenter;
-import kin.devplatform.marketplace.presenter.MarketplacePresenter;
 import kin.devplatform.network.model.Offer;
 import kin.devplatform.poll.view.PollWebViewActivity.PollBundle;
 
-public interface IMarketplaceView extends IBaseView<MarketplacePresenter> {
+public interface IMarketplaceView extends IBaseView<IMarketplacePresenter> {
 
 	void setSpendList(List<Offer> response);
 

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/marketplace/view/MarketplaceFragment.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/marketplace/view/MarketplaceFragment.java
@@ -18,7 +18,6 @@ import kin.devplatform.base.BaseRecyclerAdapter.OnItemClickListener;
 import kin.devplatform.exception.ClientException;
 import kin.devplatform.marketplace.presenter.IMarketplacePresenter;
 import kin.devplatform.marketplace.presenter.ISpendDialogPresenter;
-import kin.devplatform.marketplace.presenter.MarketplacePresenter;
 import kin.devplatform.network.model.Offer;
 import kin.devplatform.network.model.Offer.OfferType;
 import kin.devplatform.poll.view.PollWebViewActivity;
@@ -55,7 +54,7 @@ public class MarketplaceFragment extends Fragment implements IMarketplaceView {
 	}
 
 	@Override
-	public void attachPresenter(MarketplacePresenter presenter) {
+	public void attachPresenter(IMarketplacePresenter presenter) {
 		marketplacePresenter = presenter;
 	}
 


### PR DESCRIPTION
#### Main purpose:
Support activity recreation in EcosystemActivity, prevents a crash after activity restart in OrderHistory.
https://github.com/kinecosystem/kin-ecosystem-android-sdk/pull/196
#### Technical description:
#### Dilemmas you faced with?
#### Tests
#### Documentation (Source/readme.md)
