### PR TITLE
DP-234 - order never ends due to payment listener problems

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/BlockchainSource.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/BlockchainSource.java
@@ -5,12 +5,13 @@ import android.support.annotation.Nullable;
 import com.kin.ecosystem.recovery.KeyStoreProvider;
 import java.math.BigDecimal;
 import kin.core.KinAccount;
+import kin.core.exception.OperationFailedException;
 import kin.devplatform.KinCallback;
 import kin.devplatform.base.Observer;
 import kin.devplatform.data.model.Balance;
 import kin.devplatform.data.model.Payment;
 import kin.devplatform.exception.BlockchainException;
-import kin.devplatform.network.model.Offer.OfferType;
+import kin.devplatform.network.model.OpenOrder;
 
 public interface BlockchainSource {
 
@@ -30,10 +31,10 @@ public interface BlockchainSource {
 	 *
 	 * @param publicAddress the recipient address
 	 * @param amount the amount to send
-	 * @param orderID the orderID to be included in the memo of the transaction
 	 */
+	@NonNull
 	void sendTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount,
-		@NonNull String orderID, @NonNull String offerID, OfferType offerType);
+		@NonNull OpenOrder order) throws OperationFailedException;
 
 	/**
 	 * @return the cached balance.

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/BlockchainSourceImpl.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/BlockchainSourceImpl.java
@@ -13,7 +13,6 @@ import kin.core.KinClient;
 import kin.core.ListenerRegistration;
 import kin.core.PaymentInfo;
 import kin.core.ResultCallback;
-import kin.core.TransactionId;
 import kin.core.exception.CreateAccountException;
 import kin.core.exception.OperationFailedException;
 import kin.devplatform.KinCallback;
@@ -38,6 +37,7 @@ import kin.devplatform.data.model.Balance;
 import kin.devplatform.data.model.Payment;
 import kin.devplatform.exception.BlockchainException;
 import kin.devplatform.network.model.Offer.OfferType;
+import kin.devplatform.network.model.OpenOrder;
 import kin.devplatform.util.ErrorUtil;
 
 public class BlockchainSourceImpl implements BlockchainSource {
@@ -136,42 +136,54 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 	@Override
 	public void sendTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
-		@NonNull final String orderID, @NonNull final String offerID, final OfferType offerType) {
-		if (offerType == OfferType.SPEND) {
-			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
-		} else if (offerType == OfferType.PAY_TO_USER) {
-			eventLogger.send(PayToUserTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
-		}
-		account.sendTransaction(publicAddress, amount, generateMemo(orderID)).run(
-			new ResultCallback<TransactionId>() {
-				@Override
-				public void onResult(TransactionId result) {
-					if (offerType == OfferType.SPEND) {
-						eventLogger
-							.send(SpendTransactionBroadcastToBlockchainSucceeded.create(result.id(), offerID, orderID));
-					} else if (offerType == OfferType.PAY_TO_USER) {
-						eventLogger
-							.send(PayToUserTransactionBroadcastToBlockchainSucceeded
-								.create(result.id(), offerID, orderID));
-					}
-					Logger.log(new Log().withTag(TAG).put("sendTransaction onResult", result.id()));
-				}
+		@NonNull OpenOrder order) throws OperationFailedException {
+		OfferType offerType = order.getOfferType();
+		String offerId = order.getOfferId();
+		String orderId = order.getId();
 
-				@Override
-				public void onError(Exception e) {
-					if (offerType == OfferType.SPEND) {
-						eventLogger
-							.send(SpendTransactionBroadcastToBlockchainFailed
-								.create(ErrorUtil.getPrintableStackTrace(e), offerID, orderID, "", e.getMessage()));
-					} else if (offerType == OfferType.PAY_TO_USER) {
-						eventLogger
-							.send(PayToUserTransactionBroadcastToBlockchainFailed
-								.create(ErrorUtil.getPrintableStackTrace(e), offerID, orderID, "", e.getMessage()));
-					}
-					completedPayment.postValue(new Payment(orderID, false, e));
-					Logger.log(new Log().withTag(TAG).put("sendTransaction onError", e.getMessage()));
-				}
-			});
+		sendBroadcastToBlockchainSubmittedEvent(offerType, offerId, orderId);
+		try {
+			String transactionId = account.sendTransactionSync(publicAddress, amount, generateMemo(orderId))
+				.id();
+			sendTransactionSucceededEvent(offerType, offerId, orderId, transactionId);
+			Logger.log(new Log().withTag(TAG).put("sendTransaction onResult", transactionId));
+		} catch (OperationFailedException e) {
+			sendTransactionFailedEvent(offerType, offerId, orderId, e);
+			completedPayment.postValue(new Payment(orderId, false, e));
+			throw e;
+		}
+	}
+
+	private void sendBroadcastToBlockchainSubmittedEvent(OfferType offerType, String offerId, String orderId) {
+		if (offerType == OfferType.SPEND) {
+			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerId, orderId));
+		} else if (offerType == OfferType.PAY_TO_USER) {
+			eventLogger
+				.send(PayToUserTransactionBroadcastToBlockchainSubmitted.create(offerId, orderId));
+		}
+	}
+
+	private void sendTransactionSucceededEvent(OfferType offerType, String offerId, String orderId,
+		String transactionId) {
+		if (offerType == OfferType.SPEND) {
+			eventLogger
+				.send(SpendTransactionBroadcastToBlockchainSucceeded.create(transactionId, offerId, orderId));
+		} else if (offerType == OfferType.PAY_TO_USER) {
+			eventLogger
+				.send(PayToUserTransactionBroadcastToBlockchainSucceeded
+					.create(transactionId, offerId, orderId));
+		}
+	}
+
+	private void sendTransactionFailedEvent(OfferType offerType, String offerId, String orderId,
+		OperationFailedException e) {
+		if (offerType == OfferType.SPEND) {
+			eventLogger.send(SpendTransactionBroadcastToBlockchainFailed
+				.create(ErrorUtil.getPrintableStackTrace(e), offerId, orderId, "", e.getMessage()));
+		} else if (offerType == OfferType.PAY_TO_USER) {
+			eventLogger.send(PayToUserTransactionBroadcastToBlockchainFailed
+				.create(ErrorUtil.getPrintableStackTrace(e), offerId, orderId, "", e.getMessage()));
+		}
 	}
 
 	@SuppressLint("DefaultLocale")

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/ExternalEarnOrderCall.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/ExternalEarnOrderCall.java
@@ -12,7 +12,8 @@ class ExternalEarnOrderCall extends CreateExternalOrderCall {
 		@NonNull BlockchainSource blockchainSource,
 		@NonNull String orderJwt,
 		@NonNull EventLogger eventLogger,
+		long paymentListenerTimeout,
 		@NonNull ExternalOrderCallbacks externalEarnOrderCallbacks) {
-		super(remote, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks);
+		super(remote, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks, paymentListenerTimeout);
 	}
 }

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/ExternalSpendOrderCall.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/ExternalSpendOrderCall.java
@@ -12,7 +12,9 @@ class ExternalSpendOrderCall extends CreateExternalOrderCall {
 		@NonNull BlockchainSource blockchainSource,
 		@NonNull String orderJwt,
 		@NonNull EventLogger eventLogger,
-		@NonNull ExternalSpendOrderCallbacks externalSpendOrderCallbacks) {
-		super(remote, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks);
+		long paymentListenerTimeout,
+		@NonNull ExternalSpendOrderCallbacks externalSpendOrderCallbacks
+	) {
+		super(remote, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks, paymentListenerTimeout);
 	}
 }

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/OrderDataSource.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/order/OrderDataSource.java
@@ -20,7 +20,7 @@ public interface OrderDataSource {
 
 	void createOrder(@NonNull final String offerID, final KinCallback<OpenOrder> callback);
 
-	void submitOrder(@NonNull String offerID, @Nullable String content, @NonNull String orderID,
+	void submitOrder(OpenOrder order, @Nullable String content,
 		kin.devplatform.network.model.Origin origin, @Nullable KinCallback<Order> callback);
 
 	void cancelOrder(@NonNull final String offerID, @NonNull final String orderID, final KinCallback<Void> callback);

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/poll/presenter/PollWebViewPresenter.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/poll/presenter/PollWebViewPresenter.java
@@ -157,7 +157,7 @@ public class PollWebViewPresenter extends BasePresenter<IPollWebView> implements
 			final String orderId = openOrder.getId();
 			eventLogger.send(EarnOrderCompletionSubmitted
 				.create(offerID, orderId, EarnOrderCompletionSubmitted.Origin.MARKETPLACE));
-			orderRepository.submitOrder(offerID, result, orderId, kin.devplatform.network.model.Origin.MARKETPLACE,
+			orderRepository.submitOrder(openOrder, result, kin.devplatform.network.model.Origin.MARKETPLACE,
 				new KinCallback<Order>() {
 					@Override
 					public void onResponse(Order response) {

--- a/kin-devplatform-sdk/src/test/java/kin/devplatform/data/blockchain/BlockchainSourceImplTest.java
+++ b/kin-devplatform-sdk/src/test/java/kin/devplatform/data/blockchain/BlockchainSourceImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -21,6 +22,7 @@ import kin.core.KinClient;
 import kin.core.Request;
 import kin.core.ResultCallback;
 import kin.core.TransactionId;
+import kin.core.exception.OperationFailedException;
 import kin.devplatform.BaseTestClass;
 import kin.devplatform.base.Observer;
 import kin.devplatform.bi.EventLogger;
@@ -29,6 +31,7 @@ import kin.devplatform.bi.events.SpendTransactionBroadcastToBlockchainSucceeded;
 import kin.devplatform.data.model.Balance;
 import kin.devplatform.data.model.Payment;
 import kin.devplatform.network.model.Offer.OfferType;
+import kin.devplatform.network.model.OpenOrder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -88,6 +91,7 @@ public class BlockchainSourceImplTest extends BaseTestClass {
 		when(kinAccount.getBalance()).thenReturn(getBalanceReq);
 		when(balanceObj.value()).thenReturn(new BigDecimal(20));
 		when(kinAccount.getPublicAddress()).thenReturn(PUBLIC_ADDRESS);
+
 		doNothing().when(kinAccount).activateSync();
 
 		resetInstance();
@@ -144,47 +148,41 @@ public class BlockchainSourceImplTest extends BaseTestClass {
 	}
 
 	@Test
-	public void send_transaction_succeeded() throws InterruptedException {
+	public void send_transaction_succeeded() throws InterruptedException, OperationFailedException {
 		String toAddress = "some_pub_address";
 		final BigDecimal amount = new BigDecimal(10);
 		final String orderID = "someID";
-		final String transactionID = "transactionID";
 
-		Request<TransactionId> transactionRequest = mock(Request.class);
-		ArgumentCaptor<ResultCallback<TransactionId>> resultCallbackArgumentCaptor =
-			forClass(ResultCallback.class);
-		when(kinAccount.sendTransaction(any(String.class), any(BigDecimal.class), any(String.class)))
-			.thenReturn(transactionRequest);
-
+		when(kinAccount.sendTransactionSync(anyString(), (BigDecimal) any(), anyString())).thenReturn(
+			new TransactionId() {
+				@Override
+				public String id() {
+					return "transactionID";
+				}
+			});
 		blockchainSource.setAppID(APP_ID);
-		blockchainSource.sendTransaction(toAddress, amount, orderID, "offerID", OfferType.SPEND);
-		verify(transactionRequest).run(resultCallbackArgumentCaptor.capture());
-		resultCallbackArgumentCaptor.getValue().onResult(new TransactionId() {
-			@Override
-			public String id() {
-				return transactionID;
-			}
-		});
+		OpenOrder openOrder = new OpenOrder();
+		openOrder.setId(orderID);
+		openOrder.setOfferId("offerID");
+		openOrder.setOfferType(OfferType.SPEND);
+		blockchainSource.sendTransaction(toAddress, amount, openOrder);
 		verify(eventLogger).send(any(SpendTransactionBroadcastToBlockchainSucceeded.class));
 	}
 
 	@Test
-	public void send_transaction_failed() {
+	public void send_transaction_failed() throws OperationFailedException {
 		String toAddress = "some_pub_address";
 		BigDecimal amount = new BigDecimal(10);
 		final String orderID = "someID";
 
-		Request<TransactionId> transactionRequest = mock(Request.class);
-		ArgumentCaptor<ResultCallback<TransactionId>> resultCallbackArgumentCaptor =
-			forClass(ResultCallback.class);
-		when(kinAccount.sendTransaction(any(String.class), any(BigDecimal.class), any(String.class)))
-			.thenReturn(transactionRequest);
+		final OperationFailedException exception = new OperationFailedException("failed");
+		when(kinAccount.sendTransactionSync(any(String.class), any(BigDecimal.class), any(String.class)))
+			.thenThrow(exception);
 
 		blockchainSource.setAppID(APP_ID);
-		blockchainSource.sendTransaction(toAddress, amount, orderID, "offerID", OfferType.SPEND);
-		verify(transactionRequest).run(resultCallbackArgumentCaptor.capture());
-
-		final Exception exception = new Exception("failed");
+		OpenOrder openOrder = new OpenOrder();
+		openOrder.setId(orderID);
+		openOrder.setOfferType(OfferType.SPEND);
 
 		blockchainSource.addPaymentObservable(new Observer<Payment>() {
 			@Override
@@ -196,7 +194,11 @@ public class BlockchainSourceImplTest extends BaseTestClass {
 			}
 		});
 
-		resultCallbackArgumentCaptor.getValue().onError(exception);
+		try {
+			blockchainSource.sendTransaction(toAddress, amount, openOrder);
+		} catch (OperationFailedException e) {
+			e.printStackTrace();
+		}
 		verify(eventLogger).send(any(SpendTransactionBroadcastToBlockchainFailed.class));
 	}
 

--- a/sample-app/src/main/java/kin/devplatform/sample/MainActivity.java
+++ b/sample-app/src/main/java/kin/devplatform/sample/MainActivity.java
@@ -167,6 +167,7 @@ public class MainActivity extends AppCompatActivity {
 					showToast("Pay to user flow started");
 					enableView(v, false);
 					createPayToUserOffer();
+					dialog.dismiss();
 				}
 			})
 			.setNegativeButton("Cancel", null)


### PR DESCRIPTION
#### Main purpose:
 Fix a problem where orders are stuck and do not notify on success/failure.
#### Technical description:
do not rely solely on SSE notifications
spend - no need for payment listener at all, wait for sendTransaction
to return with success/failure indication
earn - add a timeout of 15 sec to payment listener, in case there's no
notification - continue to query the server for order status.
* `CreateExternalOrderCall` - reorder the flow for the aforementioned changes
* `BlockchainSourceImpl` - make sendTransaction sync as we're sending it from
a bg thread and waiting (blocking) for the result
* `OrderRepository` - remove payment listenrs in spend flows, add timeout
* `SpendDialogPresenter` - not in use in prod, just made it build
#### Dilemmas you faced with?
N/A
#### Tests
change tests to work with changed flows
#### Documentation (Source/readme.md)
N/A
