### PR TITLE
Kin.start - add fallback to account creation listener timeout

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/KinEcosystemInitiator.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/KinEcosystemInitiator.java
@@ -1,8 +1,6 @@
 package kin.devplatform;
 
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import java.util.UUID;
@@ -39,7 +37,6 @@ import kin.devplatform.util.ErrorUtil;
 public final class KinEcosystemInitiator {
 
 	private static final String KIN_ECOSYSTEM_STORE_PREFIX_KEY = "kinecosystem_store";
-	private static final int ACCOUNT_CREATION_TIME_OUT_MILLIS = 30000;
 	private static KinEcosystemInitiator instance;
 
 	private final ExecutorsUtil executorsUtil;
@@ -194,29 +191,18 @@ public final class KinEcosystemInitiator {
 
 	private void handleAccountNotCreatedState(final AccountManager accountManager,
 		final KinCallback<Void> loginCallback) {
-		final Handler handler = new Handler(Looper.getMainLooper());
 		final Observer<Integer> accountStateObserver = new Observer<Integer>() {
 			@Override
 			public void onChanged(@AccountState Integer value) {
 				if (value == AccountManager.ERROR) {
-					handler.removeCallbacksAndMessages(null);
 					accountManager.removeAccountStateObserver(this);
 					fireStartError(accountManager.getError(), loginCallback);
 				} else if (value == AccountManager.CREATION_COMPLETED) {
-					handler.removeCallbacksAndMessages(null);
 					accountManager.removeAccountStateObserver(this);
 					activateAccount(loginCallback);
 				}
 			}
 		};
-
-		handler.postDelayed(new Runnable() {
-			@Override
-			public void run() {
-				accountManager.removeAccountStateObserver(accountStateObserver);
-				fireStartError(ErrorUtil.createCreateAccountTimeoutException(), loginCallback);
-			}
-		}, ACCOUNT_CREATION_TIME_OUT_MILLIS);
 		accountManager.addAccountStateObserver(accountStateObserver);
 		accountManager.start();
 	}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/accountmanager/AccountManagerImpl.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/accountmanager/AccountManagerImpl.java
@@ -1,9 +1,14 @@
 package kin.devplatform.accountmanager;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.text.format.DateUtils;
 import kin.core.EventListener;
 import kin.core.KinAccount;
 import kin.core.ListenerRegistration;
+import kin.core.ResultCallback;
+import kin.core.exception.AccountNotActivatedException;
 import kin.devplatform.KinCallback;
 import kin.devplatform.Log;
 import kin.devplatform.Logger;
@@ -22,6 +27,7 @@ import kin.devplatform.util.ErrorUtil;
 public class AccountManagerImpl implements AccountManager {
 
 	private static final String TAG = AccountManagerImpl.class.getSimpleName();
+	private static final long ACCOUNT_CREATION_TIME_OUT_MILLIS = 15 * DateUtils.SECOND_IN_MILLIS;
 
 	private static volatile AccountManagerImpl instance;
 
@@ -109,36 +115,10 @@ public class AccountManagerImpl implements AccountManager {
 			this.accountState.postValue(accountState);
 			switch (accountState) {
 				case REQUIRE_CREATION:
-					eventLogger.send(StellarAccountCreationRequested.create());
-					Logger.log(new Log().withTag(TAG).put("setAccountState", "REQUIRE_CREATION"));
-					// Trigger account creation from server side.
-					authRepository.getAuthToken(new KinCallback<AuthToken>() {
-						@Override
-						public void onResponse(AuthToken response) {
-							setAccountState(PENDING_CREATION);
-						}
-
-						@Override
-						public void onFailure(KinEcosystemException error) {
-							instance.error = error;
-							setAccountState(ERROR);
-						}
-					});
+					handleRequiresCreationState();
 					break;
 				case PENDING_CREATION:
-					Logger.log(new Log().withTag(TAG).put("setAccountState", "PENDING_CREATION"));
-					// Start listen for account creation on the blockchain side.
-					if (accountCreationRegistration != null) {
-						removeAccountCreationRegistration();
-					}
-					accountCreationRegistration = getKinAccount().blockchainEvents()
-						.addAccountCreationListener(new EventListener<Void>() {
-							@Override
-							public void onEvent(Void data) {
-								removeAccountCreationRegistration();
-								setAccountState(REQUIRE_TRUSTLINE);
-							}
-						});
+					handlePendingCreationState();
 					break;
 				case REQUIRE_TRUSTLINE:
 					Logger.log(new Log().withTag(TAG).put("setAccountState", "REQUIRE_TRUSTLINE"));
@@ -168,6 +148,84 @@ public class AccountManagerImpl implements AccountManager {
 
 			}
 		}
+	}
+
+	private void handleRequiresCreationState() {
+		eventLogger.send(StellarAccountCreationRequested.create());
+		Logger.log(new Log().withTag(TAG).put("setAccountState", "REQUIRE_CREATION"));
+		// Trigger account creation from server side, if not triggered already
+		if (authRepository.getCachedAuthToken() == null) {
+			authRepository.getAuthToken(new KinCallback<AuthToken>() {
+				@Override
+				public void onResponse(AuthToken response) {
+					setAccountState(PENDING_CREATION);
+				}
+
+				@Override
+				public void onFailure(KinEcosystemException error) {
+					instance.error = error;
+					setAccountState(ERROR);
+				}
+			});
+		} else {
+			setAccountState(PENDING_CREATION);
+		}
+	}
+
+	private void handlePendingCreationState() {
+		Logger.log(new Log().withTag(TAG).put("setAccountState", "PENDING_CREATION"));
+		// Start listen for account creation on the blockchain side.
+		final Handler handler = new Handler(Looper.getMainLooper());
+		if (accountCreationRegistration != null) {
+			removeAccountCreationRegistration();
+		}
+
+		prepareAccountCreationTimeoutFallback(handler);
+		accountCreationRegistration = getKinAccount().blockchainEvents()
+			.addAccountCreationListener(new EventListener<Void>() {
+				@Override
+				public void onEvent(Void data) {
+					handler.post(new Runnable() {
+						@Override
+						public void run() {
+							removeAccountCreationRegistration();
+							handler.removeCallbacksAndMessages(null);
+							setAccountState(REQUIRE_TRUSTLINE);
+						}
+					});
+				}
+			});
+	}
+
+	private void prepareAccountCreationTimeoutFallback(final Handler handler) {
+		handler.postDelayed(new Runnable() {
+			@Override
+			public void run() {
+				Logger.log(new Log().withTag(TAG).put("PENDING_CREATION", "failed with timeout, querying blockchain"));
+				removeAccountCreationRegistration();
+				handler.removeCallbacksAndMessages(null);
+				//in case of SSE listening timeout, rely on direct call to blockchain for checking account creation
+				getKinAccount().getBalance().run(new ResultCallback<kin.core.Balance>() {
+					@Override
+					public void onResult(kin.core.Balance result) {
+						//result means we have account created successfully on kin blockchain
+						setAccountState(REQUIRE_TRUSTLINE);
+					}
+
+					@Override
+					public void onError(Exception e) {
+						if (e instanceof AccountNotActivatedException) {
+							//Account not activated means that we have a created account but no trustline, this is the
+							//expected result as we should establish trustline in the next state
+							setAccountState(REQUIRE_TRUSTLINE);
+						} else {
+							instance.error = ErrorUtil.createCreateAccountTimeoutException(e);
+							setAccountState(ERROR);
+						}
+					}
+				});
+			}
+		}, ACCOUNT_CREATION_TIME_OUT_MILLIS);
 	}
 
 	@Override

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthDataSource.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthDataSource.java
@@ -28,6 +28,7 @@ public interface AuthDataSource {
 
 	void getAuthToken(@Nullable final KinCallback<AuthToken> callback);
 
+	@Nullable
 	AuthToken getCachedAuthToken();
 
 	AuthToken getAuthTokenSync();

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthDataSource.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthDataSource.java
@@ -28,6 +28,8 @@ public interface AuthDataSource {
 
 	void getAuthToken(@Nullable final KinCallback<AuthToken> callback);
 
+	AuthToken getCachedAuthToken();
+
 	AuthToken getAuthTokenSync();
 
 	boolean isActivated();

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthRepository.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthRepository.java
@@ -114,6 +114,11 @@ public class AuthRepository implements AuthDataSource {
 	}
 
 	@Override
+	public AuthToken getCachedAuthToken() {
+		return cachedAuthToken;
+	}
+
+	@Override
 	public AuthToken getAuthTokenSync() {
 		if (cachedAuthToken != null) {
 			return cachedAuthToken;

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthRepository.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/auth/AuthRepository.java
@@ -114,6 +114,7 @@ public class AuthRepository implements AuthDataSource {
 	}
 
 	@Override
+	@Nullable
 	public AuthToken getCachedAuthToken() {
 		return cachedAuthToken;
 	}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
@@ -166,9 +166,9 @@ public class ErrorUtil {
 	}
 
 	@SuppressLint("DefaultLocale")
-	public static BlockchainException createCreateAccountTimeoutException() {
+	public static BlockchainException createCreateAccountTimeoutException(Exception e) {
 		return new BlockchainException(BlockchainException.ACCOUNT_CREATION_TIMEOUT,
-			ACCOUNT_CREATION_TIMEOUT, null);
+			ACCOUNT_CREATION_TIMEOUT, e);
 	}
 
 	public static String getPrintableStackTrace(Throwable t) {


### PR DESCRIPTION
#### Main purpose:
 in case of listener timeout, ask blockchain for balance for checking
account creation.
#### Technical description:
* timeout logic moved to AccountManagerImpl where it truly belongs
* check for a cached token in order to prevent calling login/get auth token call
twice
#### Dilemmas you faced with?
N/A
#### Tests
Tested on production with real cases where listener did not fired.
#### Documentation (Source/readme.md)
N/A