### PR TITLE
Various fixes

### DIFF
--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/Kin.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/Kin.java
@@ -1,5 +1,6 @@
 package kin.devplatform;
 
+
 import static kin.devplatform.exception.ClientException.SDK_NOT_STARTED;
 
 import android.app.Activity;

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/KinEcosystemInitiator.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/KinEcosystemInitiator.java
@@ -222,6 +222,7 @@ public final class KinEcosystemInitiator {
 				if (migrationCallback != null) {
 					migrationCallback.onError(e);
 				}
+				fireStartError(ErrorUtil.createMigrationFailureException(e), loginCallback);
 			}
 		});
 	}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/KeyStoreProviderImpl.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/data/blockchain/KeyStoreProviderImpl.java
@@ -11,12 +11,11 @@ import com.kin.ecosystem.recovery.KeyStoreProvider;
 import com.kin.ecosystem.recovery.Validator;
 import com.kin.ecosystem.recovery.exception.BackupException;
 import java.util.regex.Pattern;
-
-import kin.sdk.migration.interfaces.IKinAccount;
-import kin.sdk.migration.interfaces.IKinClient;
 import kin.sdk.migration.exception.CorruptedDataException;
 import kin.sdk.migration.exception.CreateAccountException;
 import kin.sdk.migration.exception.CryptoException;
+import kin.sdk.migration.interfaces.IKinAccount;
+import kin.sdk.migration.interfaces.IKinClient;
 
 public class KeyStoreProviderImpl implements KeyStoreProvider {
 
@@ -29,7 +28,8 @@ public class KeyStoreProviderImpl implements KeyStoreProvider {
 	KeyStoreProviderImpl(@NonNull final IKinClient kinClient, @NonNull final IKinAccount kinAccount) {
 		this.kinClient = kinClient;
 		this.kinAccount = kinAccount;
-		this.pattern = Pattern.compile("^(?=.*\\d)(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}\\[\\]])(?!.*[^a-zA-Z0-9!@#$%^&*()_+{}\\[\\]])(.{9,})$");
+		this.pattern = Pattern
+			.compile("^(?=.*\\d)(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}\\[\\]])(?!.*[^a-zA-Z0-9!@#$%^&*()_+{}\\[\\]])(.{9,})$");
 	}
 
 	@Override
@@ -51,9 +51,11 @@ public class KeyStoreProviderImpl implements KeyStoreProvider {
 		Validator.checkNotNull(keystore, "password");
 		try {
 			IKinAccount importedAccount = kinClient.importAccount(keystore, password);
+			String importedPublicAddress = importedAccount.getPublicAddress();
 			int index = -1;
 			for (int i = 0; i < kinClient.getAccountCount(); i++) {
-				if (importedAccount == kinClient.getAccount(i)) {
+				if (importedPublicAddress != null &&
+					importedPublicAddress.equals(kinClient.getAccount(i).getPublicAddress())) {
 					index = i;
 				}
 			}

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/exception/BlockchainException.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/exception/BlockchainException.java
@@ -8,7 +8,8 @@ public class BlockchainException extends KinEcosystemException {
 
 	@IntDef({ACCOUNT_CREATION_FAILED, ACCOUNT_NOT_FOUND,
 		ACCOUNT_ACTIVATION_FAILED, INSUFFICIENT_KIN,
-		TRANSACTION_FAILED, ACCOUNT_LOADING_FAILED, ACCOUNT_CREATION_TIMEOUT, MIGRATION_IS_NEEDED, UNKNOWN})
+		TRANSACTION_FAILED, ACCOUNT_LOADING_FAILED, ACCOUNT_CREATION_TIMEOUT, MIGRATION_IS_NEEDED, MIGRATION_FAILURE,
+		UNKNOWN})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface BlockchainErrorCodes {
 
@@ -22,6 +23,7 @@ public class BlockchainException extends KinEcosystemException {
 	public static final int ACCOUNT_LOADING_FAILED = 6006;
 	public static final int ACCOUNT_CREATION_TIMEOUT = 6007;
 	public static final int MIGRATION_IS_NEEDED = 6008;
+	public static final int MIGRATION_FAILURE = 6009;
 
 	public BlockchainException(@BlockchainErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/exception/ClientException.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/exception/ClientException.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 public class ClientException extends KinEcosystemException {
 
 	@IntDef({SDK_NOT_STARTED, BAD_CONFIGURATION, INTERNAL_INCONSISTENCY,
-		ORDER_NOT_FOUND, INCORRECT_APP_ID, BAD_JWT, SDK_IS_NOT_STARTED})
+		ORDER_NOT_FOUND, INCORRECT_APP_ID, BAD_JWT})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface ClientErrorCodes {
 
@@ -17,8 +17,6 @@ public class ClientException extends KinEcosystemException {
 	public static final int BAD_CONFIGURATION = 4002;
 	public static final int INTERNAL_INCONSISTENCY = 4003;
 	public static final int ORDER_NOT_FOUND = 4004;
-	public static final int ACCOUNT_NOT_LOGGED_IN = 4005;
-	public static final int SDK_IS_NOT_STARTED = 4005;
 	public static final int INCORRECT_APP_ID = 4006; // user appId is not equals to the appId we got from server.
 	public static final int BAD_JWT = 4007;
 

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
@@ -49,6 +49,7 @@ public class ErrorUtil {
 	private static final String ORDER_NOT_FOUND = "Cannot found a order";
 	private static final String THEE_APP_ID_IS_INCORRECT = "The supplied app id is not the same as the app id found on the server";
 	private static final String ACCOUNT_CREATION_TIMEOUT = "Account creation has timeout";
+	private static final String MIGRATION_FAILURE_MSG = "Migrating client to new blockchain has failed. cannot start the SDK";
 	private static final String BAD_JWT = "Bad or missing jwt";
 
 
@@ -177,6 +178,12 @@ public class ErrorUtil {
 	public static BlockchainException createCreateAccountTimeoutException(Exception e) {
 		return new BlockchainException(BlockchainException.ACCOUNT_CREATION_TIMEOUT,
 			ACCOUNT_CREATION_TIMEOUT, e);
+	}
+
+	@SuppressLint("DefaultLocale")
+	public static BlockchainException createMigrationFailureException(Exception e) {
+		return new BlockchainException(BlockchainException.MIGRATION_FAILURE,
+			MIGRATION_FAILURE_MSG, e);
 	}
 
 	public static String getPrintableStackTrace(Throwable t) {

--- a/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
+++ b/kin-devplatform-sdk/src/main/java/kin/devplatform/util/ErrorUtil.java
@@ -43,11 +43,10 @@ public class ErrorUtil {
 	private static final String FAILED_TO_CREATE_A_BLOCKCHAIN_WALLET_KEYPAIR = "Failed to create a blockchain wallet keypair";
 	private static final String THE_REQUESTED_ACCOUNT_COULD_NOT_BE_FOUND = "The requested account could not be found";
 	private static final String FAILED_TO_ACTIVATE_ON_THE_BLOCKCHAIN_NETWORK = "A Wallet was created locally, but failed to activate on the blockchain network";
-	private static final String ECOSYSTEM_SDK_IS_NOT_STARTED = "Operation not permitted: Ecosystem SDK is not started, please call Kin.initialize(...) first.";
+	private static final String ECOSYSTEM_SDK_IS_NOT_STARTED = "SDK is not started, please call Kin.start(...) first..";
 	private static final String BAD_OR_MISSING_PARAMETERS = "Bad or missing parameters";
 	private static final String FAILED_TO_LOAD_ACCOUNT_ON_INDEX = "Failed to load blockchain wallet on index %d";
 	private static final String ORDER_NOT_FOUND = "Cannot found a order";
-	private static final String SDK_IS_NOT_STARTED_IN = "SDK is not started, please call Kin.start(...) first.";
 	private static final String THEE_APP_ID_IS_INCORRECT = "The supplied app id is not the same as the app id found on the server";
 	private static final String ACCOUNT_CREATION_TIMEOUT = "Account creation has timeout";
 	private static final String BAD_JWT = "Bad or missing jwt";
@@ -152,9 +151,6 @@ public class ErrorUtil {
 				break;
 			case ClientException.ORDER_NOT_FOUND:
 				exception = new ClientException(ClientException.ORDER_NOT_FOUND, ORDER_NOT_FOUND, e);
-				break;
-			case ClientException.SDK_IS_NOT_STARTED:
-				exception = new ClientException(ClientException.SDK_IS_NOT_STARTED, SDK_IS_NOT_STARTED_IN, e);
 				break;
 			case INCORRECT_APP_ID:
 				exception = new ClientException(INCORRECT_APP_ID, THEE_APP_ID_IS_INCORRECT, e);


### PR DESCRIPTION
* really fix the not started sdk error message (previously I've changed an unuse const + msg)
* bug fix - migration failure didn't fire start error callback
* DP-256 - restore account not working: find imported account correctly by comparing public address and not references that we have no guarantee that will be equal